### PR TITLE
'--quiet' option might not be specified in VALAFLAGS

### DIFF
--- a/wscript
+++ b/wscript
@@ -152,7 +152,8 @@ def configure(ctx):
 		ctx.check_vala(min_version=(0,22,1))
 	
 	# Don't be quiet
-	ctx.env.VALAFLAGS.remove("--quiet")
+	if "--quiet" in ctx.env.VALAFLAGS:
+		ctx.env.VALAFLAGS.remove("--quiet")
 	ctx.env.append_value("VALAFLAGS", "-v")
 	
 	# enable threading


### PR DESCRIPTION
This option is removed since waf-1.8.14.

https://github.com/waf-project/waf/commit/8ba068670a973f6064faad104d8a37bb6f5abccd#diff-605182763c138cd132445b3d2df0abe5R341